### PR TITLE
Stripe customer details should be saved

### DIFF
--- a/app/models/django.py
+++ b/app/models/django.py
@@ -24,7 +24,7 @@ class User(AbstractUser):
                 # Refetch customer data
                 customer = stripe.Customer.retrieve(self.stripe_customer.id)
                 djstripe.models.Customer.sync_from_stripe_data(customer)
-                # Get subscriptions
+                # Update subscriptions
                 self.stripe_customer._sync_subscriptions()
         except:
             pass

--- a/app/models/wagtail.py
+++ b/app/models/wagtail.py
@@ -109,6 +109,12 @@ class HomePage(RoutablePageMixin, Page):
                 cancel_url=urllib.parse.urljoin(
                     self.get_full_url(request), self.reverse_subpage("pick_product")
                 ),
+                # By default, customer details aren't updated, but we want them to be.
+                customer_update={
+                    "shipping": "auto",
+                    "address": "auto",
+                    "name": "auto",
+                },
             )
         )(request)
 


### PR DESCRIPTION
Makes sure that Stripe data from checkout is applied to the customer, so they can update their details later.