### PR TITLE
Fix promo codes for migrated gift subscriptions

### DIFF
--- a/app/oauth.py
+++ b/app/oauth.py
@@ -29,8 +29,10 @@ class CustomOAuth2Validator(OAuth2Validator):
             "shipping_address": request.user.shipping_address,
         }
         if request.user.primary_product != None:
-            args.update({
-                "stripe_product_name": request.user.primary_product.name,
-                "stripe_product_id": request.user.primary_product.id,
-            })
+            args.update(
+                {
+                    "stripe_product_name": request.user.primary_product.name,
+                    "stripe_product_id": request.user.primary_product.id,
+                }
+            )
         return args


### PR DESCRIPTION
Fix for the case where gift card subscription has migrated to a new product, but the generated coupon still applies only to the old product. This will check for that and handle things smoothly.

Relevant error reports:
- https://sentry.io/organizations/commonknowledge/issues/3345984329/?project=6379833&query=&statsPeriod=14d