### PR TITLE
Fix display of discounted book prices

### DIFF
--- a/app/templates/app/includes/cart_options.html
+++ b/app/templates/app/includes/cart_options.html
@@ -25,8 +25,8 @@
                     </button>
                 {% endif %}
                 <div class='tw-mt-2 fs-5 tw-font-bold'>
-                    {% if variant.compare_at_price is not None and variant.price < variant.compare_at_price %}
-                        <b>{% money_localize variant.price "GBP" %}</b> <s>{% money_localize variant.compare_at_price "GBP" %}</s>
+                    {% if variant.compare_at_price is not None and variant.price >  variant.compare_at_price %}
+                        <b>{% money_localize variant.compare_at_price "GBP" %}</b> <s>{% money_localize variant.price "GBP" %}</s>
                     {% else %}
                         {% money_localize variant.price "GBP" %}
                     {% endif %}


### PR DESCRIPTION
## Description
This PR reverses the condition check for displaying discounted book prices so that both should be displayed and in the correct order.

## Motivation and Context
Addresses issue [LBC-304](https://linear.app/commonknowledge/issue/LBC-304/ensure-website-can-display-discounted-prices-from-shopify)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

