### PR TITLE
Prevent MailChimp API error from crashing application at checkout

### DIFF
--- a/app/utils/mailchimp.py
+++ b/app/utils/mailchimp.py
@@ -64,16 +64,20 @@ def mailchimp_contact_for_user(user: User, list_id=settings.MAILCHIMP_LIST_ID):
         member = apply_gdpr_consent(member)
         return member
     except MailchimpApiClientError:
-        member = mailchimp.lists.add_list_member(
-            list_id,
-            {
-                "email_address": user.primary_email,
-                "merge_fields": {"FNAME": user.first_name, "LNAME": user.last_name},
-                "status": "subscribed" if user.gdpr_email_consent else "unsubscribed",
-            },
-        )
-        member = apply_gdpr_consent(member)
-        return member
+        try:
+            member = mailchimp.lists.add_list_member(
+                list_id,
+                {
+                    "email_address": user.primary_email,
+                    "merge_fields": {"FNAME": user.first_name, "LNAME": user.last_name},
+                    "status": "subscribed" if user.gdpr_email_consent else "unsubscribed",
+                },
+            )
+            member = apply_gdpr_consent(member)
+            return member
+        except MailchimpApiClientError as e:
+            print(f"Failed to add list member: {e}")
+            return None
 
 
 def tag_user_in_mailchimp(user: User, tags_to_enable=list(), tags_to_disable=list()):


### PR DESCRIPTION

## Description
This PR adds some additional error handling to the mailchimp.lists.add_list_member method - we return None rather than assuming we will always get a member
This would prevent the app from crashing on this error until we can investigate it thoroughly 

## Motivation and Context
A temporary fix for Sentry issue. Issue captured in [LBC-403](https://linear.app/commonknowledge/issue/LBC-403/investigate-mailchimpapiclienterror-at-checkout)

## How Will This Be Deployed?
Normal deployment process


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

