### PR TITLE
Return all countries (not shipping zones) when user is buying a gift subscription

### DIFF
--- a/app/templates/app/frames/shipping_cost.html
+++ b/app/templates/app/frames/shipping_cost.html
@@ -42,7 +42,7 @@
     </div>
     {% bootstrap_alert "This subscription will automatically renew, and you can cancel at any time." dismissible=False alert_type="success" extra_classes='mb-2' %}
     {% if request.GET.gift_mode %}
-        {% bootstrap_alert "At checkout, please add your own shipping address, in case we need to send you any gift card materials. Your gift recipient will be able to enter their own address when they redeem." dismissible=False alert_type="warning" extra_classes='mb-2' %}
+        {% bootstrap_alert "At checkout, please add your own shipping address, in case we need to send you any gift card materials. Your gift recipient will be able to enter their own address when they redeem." dismissible=False alert_type="warning" extra_classes='mb-2 text-light bg-danger' %}
     {% endif %}
     {% if user.is_member and not request.GET.gift_mode %}
         <div class='justify-content-center'>

--- a/app/templates/app/frames/shipping_cost.html
+++ b/app/templates/app/frames/shipping_cost.html
@@ -41,9 +41,6 @@
         </div>
     </div>
     {% bootstrap_alert "This subscription will automatically renew, and you can cancel at any time." dismissible=False alert_type="success" extra_classes='mb-2' %}
-    {% if request.GET.gift_mode %}
-        {% bootstrap_alert "At checkout, please add your own shipping address, in case we need to send you any gift card materials. Your gift recipient will be able to enter their own address when they redeem." dismissible=False alert_type="warning" extra_classes='mb-2 text-light bg-danger' %}
-    {% endif %}
     {% if user.is_member and not request.GET.gift_mode %}
         <div class='justify-content-center'>
             <div class="form-check max-width-card w-100">

--- a/app/templates/app/frames/shipping_cost.html
+++ b/app/templates/app/frames/shipping_cost.html
@@ -41,6 +41,9 @@
         </div>
     </div>
     {% bootstrap_alert "This subscription will automatically renew, and you can cancel at any time." dismissible=False alert_type="success" extra_classes='mb-2' %}
+    {% if request.GET.gift_mode %}
+        {% bootstrap_alert "At checkout, please add your own shipping address, in case we need to send you any gift card materials. Your gift recipient will be able to enter their own address when they redeem." dismissible=False alert_type="warning" extra_classes='mb-2 text-light bg-danger' %}
+    {% endif %}
     {% if user.is_member and not request.GET.gift_mode %}
         <div class='justify-content-center'>
             <div class="form-check max-width-card w-100">
@@ -49,7 +52,7 @@
                        type="checkbox"
                        value=""
                        id='confirm_cancel_current_subscriptions'
-                       name='confirm_cancel_current_subscriptions'/>
+                       name='confirm_cancel_current_subscriptions' />
                 <label class="form-check-label" for="confirm_cancel_current_subscriptions">
                     <p>
                         I understand that my existing membership plan ({{ user.primary_product.name }}) will be <u>immediately cancelled</u> and replaced with this new subscription

--- a/app/views.py
+++ b/app/views.py
@@ -1297,6 +1297,10 @@ class V2SubscriptionCheckoutView(TemplateView):
         next = "/"
         if gift_mode:
             checkout_args["metadata"]["gift_mode"] = True
+            checkout_args["shipping_address_collection"] = {
+                "allowed_countries": ShippingZone.all_country_codes
+
+            }
             next = reverse_lazy("completed_gift_purchase")
         else:
             next = reverse_lazy("completed_membership_purchase")


### PR DESCRIPTION
## Description
This PR changes the countries drop down for shipping address in the Stripe checkout view when buying a gift subscription.
This is because users may want to send a gift subscription to someone in ROW but need to input their UK address in the checkout. 
Gift recipients enter their own address when they redeem their gift card

## Motivation and Context
Addresses issue [LBC-395](url)

## How Can It Be Tested?
This is live at https://leftbookclub.onrender.com/
Follow the flow for buying a gift membership and pick a shipping country that is not UK
Go through the Stripe test checkout and select a UK shipping and billing address
[Stripe test cards 
](https://docs.stripe.com/testing?locale=en-GB#international-cards)

## How Will This Be Deployed?
Normal deployment process


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

