### PR TITLE
Fix bug preventing redemption of gift subscriptions

### DIFF
--- a/app/utils/stripe.py
+++ b/app/utils/stripe.py
@@ -340,14 +340,14 @@ def create_gift_recipient_subscription(
     promo_code = stripe.PromotionCode.retrieve(
         promo_code_id, expand=["coupon.applies_to"]
     )
-    if product_id in promo_code.coupon.applies_to.products:
-        # the gift card is fit for purpose
+    if hasattr(promo_code.coupon, 'applies_to') and product_id in promo_code.coupon.applies_to.products:
+    # the gift card is fit for purpose
         discount_args = {"promotion_code": promo_code_id}
+        
     else:
-        # if they're in this situation of the gift card being for an old product
-        # get the right coupon for the target product
+    # if they're in this situation of the gift card being for an old product
+    # get the right coupon for the target product
         coupon = get_gift_card_coupon(product_id)
-
         # invalidate the gift card's promo code so it can't be used again
         promo_code = stripe.PromotionCode.modify(promo_code_id, active=False)
 

--- a/app/utils/stripe.py
+++ b/app/utils/stripe.py
@@ -340,8 +340,11 @@ def create_gift_recipient_subscription(
     promo_code = stripe.PromotionCode.retrieve(
         promo_code_id, expand=["coupon.applies_to"]
     )
-    if hasattr(promo_code.coupon, 'applies_to') and product_id in promo_code.coupon.applies_to.products:
-    # the gift card is fit for purpose
+    if (
+    hasattr(promo_code.coupon, 'applies_to') and 
+    hasattr(promo_code.coupon.applies_to, 'products') and 
+    product_id in promo_code.coupon.applies_to.products
+    ):    # the gift card is fit for purpose
         discount_args = {"promotion_code": promo_code_id}
         
     else:


### PR DESCRIPTION
## Description
This PR adds an additional attribute check for applies_to attribute on coupon object returned from Stripe before checking for which products (if any) the coupon applies to.
This prevents the app from crashing due to an attribute error

## Motivation and Context
Addresses issue [LBC-404](https://linear.app/commonknowledge/issue/LBC-404/attribute-error-when-entering-shipping-address-at-gift-card-redeem)

## Motivation and Context
Download the branch and run locally
Create a gift subscription using [Stripe test cards](https://docs.stripe.com/testing?locale=en-GB#international-cards)
Copy gift card code
Sign out and go to http://127.0.0.1:8000/redeem/ 
Enter the code, create another account and add shipping details
The gift card should be redeemed successfully

## How Will This Be Deployed?
Normal deployment process

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
