### PR TITLE
Refactor the Shopify storefront to use @shopify/storefront-api-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN poetry config virtualenvs.in-project true
 
 # Python deps
 COPY --chown=app:app pyproject.toml poetry.lock ./
-RUN poetry install -n
+RUN poetry install -n --no-root
 
 # Frontend deps
 COPY package.json yarn.lock ./

--- a/app/templates/app/includes/cart.html
+++ b/app/templates/app/includes/cart.html
@@ -34,49 +34,53 @@
                 <div class='tw-my-3'>
                     <button class='btn btn-primary'
                             data-action="click->product#redirectToCheckout">
-                        Checkout: (( totalCost | currency )) + shipping
-                    </button>
+                            Checkout: (( totalCost | currency )) + shipping
+                        </button>
                 </div>
                 <div class="row gx-3 gy-3">
                     <div class='col-12 gy-3'>
                         <div class='tw-border tw-border-gray-600'></div>
                     </div>
                     ((#lineItems))
+                
                     <a class="col-5 tw-block"
-                       href="/anonymous/product/(( variantId | shopifyId ))">
-                        <img src="(( imageUrl ))" alt="(( imageAlt ))" class="tw-w-full" />
-                    </a>
-                    <div class="col-7">
-                        <a class='tw-no-underline'
-                           href="/anonymous/product/(( variantId | shopifyId ))">
-                            <h5 class='tw-font-bold tw-text-black'>(( title ))</h5>
-                        </a>
+                    href="/anonymous/product/(( variantId | shopifyId ))">                     
+                    <img src="(( imageUrl ))" alt="(( imageAlt ))" class="tw-w-full" />                 </a>
+                 <div class="col-7">
+                     <a class='tw-no-underline'
+                        href="/anonymous/product/(( variant.product.id|shopifyId ))">
+                         <h5 class='tw-font-bold tw-text-black'>(( title ))</h5>
+                     </a>
                         <div>
                             (( price | currency )) ((#compareAtPrice))<s>(( compareAtPrice | currency ))</s>((/compareAtPrice))
+                            ((#discountAllocations))
+                            <div>Discount applied!</div>
+                            <div>
+                                <b>((discountApplication.title))</b>
+                            </div>
+                            <div>Final price: ((allocatedAmount|currency))</div>
+                            ((/discountAllocations))
                         </div>
                         <div>(( quantity )) (( quantity | pluralize : "copy" : "copies" ))</div>
-                        ((#canDecreaseQuantity))
-
                         <div class='tw-mt-1'>
+                            ((#canDecreaseQuantity))
                             <button class='btn btn-outline-secondary'
-                            data-action="click->product#decrement"
-                            data-product-line-item-id="(( id ))"
-                            data-product-quantity="(( quantity ))">
-                        -1
-                    </button>
-                    ((/canDecreaseQuantity))
-
+                                    data-action="click->product#decrement"
+                                    data-product-line-item-id="(( id ))"
+                                    data-product-quantity="(( quantity ))">                                -1
+                            </button>
+                            ((/canDecreaseQuantity))
                             <button class='btn btn-outline-secondary'
-                            data-action="click->product#increment"
-                            data-product-line-item-id="(( id ))"
-                            data-product-quantity="(( quantity ))">
-                        +1
-                    </button>
+                                    data-action='click->product#increment'
+                                    data-product-line-item-id="(( id ))"
+                                    data-product-quantity="(( quantity ))">
+                                +1
+                            </button>
                             <button class='btn btn-outline-secondary'
-                            data-action='click->product#remove'
-                            data-product-line-item-id='(( id ))'>
-                      Remove
-                    </button>
+                                    data-action='click->product#remove'
+                                    data-product-line-item-id='(( id ))'>
+                                    Remove
+                            </button>
                         </div>
                     </div>
                     ((/lineItems))
@@ -87,8 +91,8 @@
                 <div class='tw-my-3'>
                     <button class='btn btn-primary'
                             data-action="click->product#redirectToCheckout">
-                        Checkout: (( totalCost | currency )) + shipping
-                    </button>
+                            Checkout: (( totalCost | currency )) + shipping
+                        </button>
                 </div>
                 ((/hasLineItems))
                 ((^lineItems))

--- a/app/templates/app/includes/cart.html
+++ b/app/templates/app/includes/cart.html
@@ -5,7 +5,7 @@
     <div class="offcanvas-header">
         <h3 id="cartLabel">Your cart</h3>
         <template data-product-target="template" data-target="#cartLabel">
-            Your cart has (( lineItems.length )) (( lineItems.length | pluralize : "item" )) totalling (( totalCost | currency ))
+            Your cart has (( totalQuantity )) (( totalQuantity | pluralize : "item" )) totalling (( totalCost | currency ))
         </template>
         <button type="button"
                 class="btn-close text-reset"

--- a/app/templates/app/includes/cart.html
+++ b/app/templates/app/includes/cart.html
@@ -55,6 +55,8 @@
                             (( price | currency )) ((#compareAtPrice))<s>(( compareAtPrice | currency ))</s>((/compareAtPrice))
                         </div>
                         <div>(( quantity )) (( quantity | pluralize : "copy" : "copies" ))</div>
+                        ((#canDecreaseQuantity))
+
                         <div class='tw-mt-1'>
                             <button class='btn btn-outline-secondary'
                             data-action="click->product#decrement"
@@ -62,6 +64,8 @@
                             data-product-quantity="(( quantity ))">
                         -1
                     </button>
+                    ((/canDecreaseQuantity))
+
                             <button class='btn btn-outline-secondary'
                             data-action="click->product#increment"
                             data-product-line-item-id="(( id ))"

--- a/app/templates/app/includes/cart.html
+++ b/app/templates/app/includes/cart.html
@@ -5,7 +5,7 @@
     <div class="offcanvas-header">
         <h3 id="cartLabel">Your cart</h3>
         <template data-product-target="template" data-target="#cartLabel">
-            Your cart has (( checkout.lineItems|length )) (( checkout.lineItems|length|pluralize:'item' )) totalling (( checkout.totalPriceV2|currency ))
+            Your cart has (( lineItems.length )) (( lineItems.length | pluralize : "item" )) totalling (( totalCost | currency ))
         </template>
         <button type="button"
                 class="btn-close text-reset"
@@ -34,7 +34,7 @@
                 <div class='tw-my-3'>
                     <button class='btn btn-primary'
                             data-action="click->product#redirectToCheckout">
-                        Checkout: ((checkout.totalPriceV2|currency)) + shipping
+                        Checkout: (( totalCost | currency )) + shipping
                     </button>
                 </div>
                 <div class="row gx-3 gy-3">
@@ -43,41 +43,34 @@
                     </div>
                     ((#lineItems))
                     <a class="col-5 tw-block"
-                       href="/anonymous/product/(( variant.product.id|shopifyId ))">
-                        <img src="(( variant.image.src ))" alt="(( title ))" class="tw-w-full" />
+                       href="/anonymous/product/(( variantId | shopifyId ))">
+                        <img src="(( imageUrl ))" alt="(( imageAlt ))" class="tw-w-full" />
                     </a>
                     <div class="col-7">
                         <a class='tw-no-underline'
-                           href="/anonymous/product/(( variant.product.id|shopifyId ))">
+                           href="/anonymous/product/(( variantId | shopifyId ))">
                             <h5 class='tw-font-bold tw-text-black'>(( title ))</h5>
                         </a>
                         <div>
-                            (( variant.priceV2|currency )) ((#compareAtPrice))<s>((compareAtPrice|currency))</s>((/compareAtPrice))
-                            ((#discountAllocations))
-                            <div>Discount applied!</div>
-                            <div>
-                                <b>((discountApplication.title))</b>
-                            </div>
-                            <div>Final price: ((allocatedAmount|currency))</div>
-                            ((/discountAllocations))
+                            (( price | currency )) ((#compareAtPrice))<s>(( compareAtPrice | currency ))</s>((/compareAtPrice))
                         </div>
-                        <div>((quantity)) (( quantity | pluralize : "copy" : "copies" ))</div>
+                        <div>(( quantity )) (( quantity | pluralize : "copy" : "copies" ))</div>
                         <div class='tw-mt-1'>
                             ((#canDecreaseQuantity))
                             <button class='btn btn-outline-secondary'
                                     data-action="click->product#decrement"
-                                    data-product-line-item-param='(( lineItem|stringify ))'>
+                                    data-product-line-item-param='(( lineItem | stringify ))'>
                                 -1
                             </button>
                             ((/canDecreaseQuantity))
                             <button class='btn btn-outline-secondary'
                                     data-action='click->product#increment'
-                                    data-product-line-item-param='(( lineItem|stringify ))'>
+                                    data-product-line-item-param='(( lineItem | stringify ))'>
                                 +1
                             </button>
                             <button class='btn btn-outline-secondary'
                                     data-action='click->product#remove'
-                                    data-product-line-item-param='(( lineItem|stringify ))'>
+                                    data-product-line-item-param='(( lineItem | stringify ))'>
                                 Remove
                             </button>
                         </div>
@@ -90,7 +83,7 @@
                 <div class='tw-my-3'>
                     <button class='btn btn-primary'
                             data-action="click->product#redirectToCheckout">
-                        Checkout: ((checkout.totalPriceV2|currency)) + shipping
+                        Checkout: (( totalCost | currency )) + shipping
                     </button>
                 </div>
                 ((/hasLineItems))

--- a/app/templates/app/includes/cart.html
+++ b/app/templates/app/includes/cart.html
@@ -56,23 +56,23 @@
                         </div>
                         <div>(( quantity )) (( quantity | pluralize : "copy" : "copies" ))</div>
                         <div class='tw-mt-1'>
-                            ((#canDecreaseQuantity))
                             <button class='btn btn-outline-secondary'
-                                    data-action="click->product#decrement"
-                                    data-product-line-item-param='(( lineItem | stringify ))'>
-                                -1
-                            </button>
-                            ((/canDecreaseQuantity))
+                            data-action="click->product#decrement"
+                            data-product-line-item-id="(( id ))"
+                            data-product-quantity="(( quantity ))">
+                        -1
+                    </button>
                             <button class='btn btn-outline-secondary'
-                                    data-action='click->product#increment'
-                                    data-product-line-item-param='(( lineItem | stringify ))'>
-                                +1
-                            </button>
+                            data-action="click->product#increment"
+                            data-product-line-item-id="(( id ))"
+                            data-product-quantity="(( quantity ))">
+                        +1
+                    </button>
                             <button class='btn btn-outline-secondary'
-                                    data-action='click->product#remove'
-                                    data-product-line-item-param='(( lineItem | stringify ))'>
-                                Remove
-                            </button>
+                            data-action='click->product#remove'
+                            data-product-line-item-id='(( id ))'>
+                      Remove
+                    </button>
                         </div>
                     </div>
                     ((/lineItems))

--- a/app/templates/app/includes/cart_icon.html
+++ b/app/templates/app/includes/cart_icon.html
@@ -11,7 +11,7 @@
              xmlns="http://www.w3.org/2000/svg">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z" />
         </svg>
-        <span class='tw-absolute -tw-top-1 -tw-right-2 tw-rounded-full tw-bg-yellow tw-tracking-normal text-black tw-no-underline tw-px-[0.25rem] !tw-text-xs tw-font-bold'>(( lineItems.length  ))</span>
+        <span class='tw-absolute -tw-top-1 -tw-right-2 tw-rounded-full tw-bg-yellow tw-tracking-normal text-black tw-no-underline tw-px-[0.25rem] !tw-text-xs tw-font-bold'>(( totalQuantity  ))</span>
         ((/hasLineItems))
     </template>
 </span>

--- a/app/templates/app/includes/cart_icon.html
+++ b/app/templates/app/includes/cart_icon.html
@@ -11,7 +11,7 @@
              xmlns="http://www.w3.org/2000/svg">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z" />
         </svg>
-        <span class='tw-absolute -tw-top-1 -tw-right-2 tw-rounded-full tw-bg-yellow tw-tracking-normal text-black tw-no-underline tw-px-[0.25rem] !tw-text-xs tw-font-bold'>(( checkout.lineItems|length ))</span>
+        <span class='tw-absolute -tw-top-1 -tw-right-2 tw-rounded-full tw-bg-yellow tw-tracking-normal text-black tw-no-underline tw-px-[0.25rem] !tw-text-xs tw-font-bold'>(( lineItems.length  ))</span>
         ((/hasLineItems))
     </template>
 </span>

--- a/app/templates/app/includes/cart_options.html
+++ b/app/templates/app/includes/cart_options.html
@@ -48,9 +48,15 @@
         </select>
     </div>
     <div>
-        <button class="btn btn-outline-secondary btn-disable-strikethrough" data-product-variant-id-param="{{ product.variants.0.id }}" data-product-target="addToCartButton" {% if product.variants.0.inventory_quantity == 0 and product.variants.0.inventory_policy == 'deny' %} disabled="true" {% elif loading or disabled %} disabled="true" {% else %} data-bs-toggle="offcanvas" data-bs-target="#cart" data-action="click->product#add"
-        {% endif %}
-        >Add to cart</button>
+        <button class="btn btn-outline-secondary btn-disable-strikethrough" 
+        data-product-variant-id-param="{{ product.variants.0.id }}"
+        data-product-target="addToCartButton"
+        data-bs-toggle="offcanvas" 
+        data-bs-target="#cart"
+        data-action="click->product#add"
+        {% if product.variants.0.inventory_quantity == 0 %} disabled="true"{% endif %}>
+    Add to cart
+</button>
 </div>
 {% endif %}
 </div>

--- a/frontend/controllers/product-controller.ts
+++ b/frontend/controllers/product-controller.ts
@@ -411,12 +411,16 @@ async add({ params: { variantId } }: any) {
         hasLineItems: cart.lines.edges.length > 0,
         lineItems: cart.lines.edges.map((edge: any) => {
           const lineItem = edge.node;
+          const productImages = lineItem.merchandise.product.images.edges;
+
           return {
             id: lineItem.id,
             quantity: lineItem.quantity,
             title: lineItem.merchandise.product.title,
             variantId: lineItem.merchandise.id,
-            canDecreaseQuantity: lineItem.quantity > 1
+            canDecreaseQuantity: lineItem.quantity > 1,
+            imageUrl: productImages?.[0]?.node?.url,
+            imageAlt: productImages?.[0]?.node?.altText
           };
         }),
         checkout: cart.checkoutUrl,

--- a/frontend/controllers/product-controller.ts
+++ b/frontend/controllers/product-controller.ts
@@ -188,7 +188,7 @@ export default class ShopifyBuyControllerBase extends Controller {
           }
         }
         cost {
-          totalAmount {
+          subtotalAmount {
             amount
             currencyCode
           }
@@ -240,9 +240,10 @@ export default class ShopifyBuyControllerBase extends Controller {
           lineItems,
           totalQuantity,
           checkout: cart.checkoutUrl,
-          totalCost: cart.cost.totalAmount.amount,
-          currency: cart.cost.totalAmount.currencyCode,
+          totalCost: cart.cost.subtotalAmount.amount,
+          currency: cart.cost.subtotalAmount.currencyCode,
         };
+        console.log(cart, "cart");
 
         this.renderCart();
 
@@ -348,7 +349,7 @@ export default class ShopifyBuyControllerBase extends Controller {
               }
             }
             cost {
-              totalAmount {
+              subtotalAmount {
                 amount
                 currencyCode
               }
@@ -444,7 +445,7 @@ export default class ShopifyBuyControllerBase extends Controller {
           }
         }
         cost {
-          totalAmount {
+          subtotalAmount {
             amount
             currencyCode
           }
@@ -492,7 +493,7 @@ export default class ShopifyBuyControllerBase extends Controller {
         });
 
         const totalQuantity = lineItems.reduce(
-          (sum, item) => sum + item.quantity,
+          (sum: any, item: { quantity: any }) => sum + item.quantity,
           0
         );
 
@@ -502,8 +503,8 @@ export default class ShopifyBuyControllerBase extends Controller {
           lineItems,
           totalQuantity,
           checkout: cart.checkoutUrl,
-          totalCost: cart.cost.totalAmount.amount,
-          currency: cart.cost.totalAmount.currencyCode,
+          totalCost: cart.cost.subtotalAmount.amount,
+          currency: cart.cost.subtotalAmount.currencyCode,
         };
       } else {
         console.error(
@@ -579,7 +580,7 @@ export default class ShopifyBuyControllerBase extends Controller {
             }
           }
           cost {
-            totalAmount {
+            subtotalAmount {
               amount
               currencyCode
             }
@@ -628,7 +629,7 @@ export default class ShopifyBuyControllerBase extends Controller {
         });
 
         const totalQuantity = lineItems.reduce(
-          (sum, item) => sum + item.quantity,
+          (sum: any, item: { quantity: any }) => sum + item.quantity,
           0
         );
         this.mustacheViewValue = {
@@ -637,8 +638,8 @@ export default class ShopifyBuyControllerBase extends Controller {
           lineItems,
           totalQuantity,
           checkout: cart.checkoutUrl,
-          totalCost: cart.cost.totalAmount.amount,
-          currency: cart.cost.totalAmount.currencyCode,
+          totalCost: cart.cost.subtotalAmount.amount,
+          currency: cart.cost.subtotalAmount.currencyCode,
         };
       } else {
         console.error(
@@ -718,7 +719,7 @@ export default class ShopifyBuyControllerBase extends Controller {
             }
           }
           cost {
-            totalAmount {
+            subtotalAmount {
               amount
               currencyCode
             }
@@ -767,7 +768,7 @@ export default class ShopifyBuyControllerBase extends Controller {
         });
 
         const totalQuantity = lineItems.reduce(
-          (sum, item) => sum + item.quantity,
+          (sum: any, item: { quantity: any }) => sum + item.quantity,
           0
         );
 
@@ -777,8 +778,8 @@ export default class ShopifyBuyControllerBase extends Controller {
           lineItems,
           totalQuantity,
           checkout: cart.checkoutUrl,
-          totalCost: cart.cost.totalAmount.amount,
-          currency: cart.cost.totalAmount.currencyCode,
+          totalCost: cart.cost.subtotalAmount.amount,
+          currency: cart.cost.subtotalAmount.currencyCode,
         };
       } else {
         console.error(
@@ -857,7 +858,7 @@ export default class ShopifyBuyControllerBase extends Controller {
             }
           }
           cost {
-            totalAmount {
+            subtotalAmount {
               amount
               currencyCode
             }
@@ -905,7 +906,7 @@ export default class ShopifyBuyControllerBase extends Controller {
         });
 
         const totalQuantity = lineItems.reduce(
-          (sum, item) => sum + item.quantity,
+          (sum: any, item: { quantity: any }) => sum + item.quantity,
           0
         );
 
@@ -915,8 +916,8 @@ export default class ShopifyBuyControllerBase extends Controller {
           lineItems,
           totalQuantity,
           checkout: cart.checkoutUrl,
-          totalCost: cart.cost.totalAmount.amount,
-          currency: cart.cost.totalAmount.currencyCode,
+          totalCost: cart.cost.subtotalAmount.amount,
+          currency: cart.cost.subtotalAmount.currencyCode,
         };
       } else {
         console.error(

--- a/frontend/controllers/product-controller.ts
+++ b/frontend/controllers/product-controller.ts
@@ -118,7 +118,7 @@ export default class ShopifyBuyControllerBase extends Controller {
       throw new Error("Shopify initialization failed: Missing domain or token");
     }
 
-    const apiUrl = `https://${this.shopifyDomainValue}/api/2024-10/graphql.json`;
+    const apiUrl = `https://${this.shopifyDomainValue}/api/2025-01/graphql.json`;
     try {
       const response = await fetch(apiUrl, {
         method: "POST",

--- a/frontend/controllers/product-controller.ts
+++ b/frontend/controllers/product-controller.ts
@@ -777,20 +777,7 @@ async increment(event: Event) {
     this.mustacheViewValue = { ...this.mustacheViewValue, loading: false };
   }
 }
-  checkoutValueChanged() {
-    this.mustacheViewValue = {
-      loading: false,
-      hasLineItems: this.checkoutValue?.lineItems?.length || 0 > 0,
-      lineItems: this.checkoutValue?.lineItems?.map((lineItem) => {
-        return {
-          ...lineItem,
-          lineItem,
-          canDecreaseQuantity: lineItem.quantity > 1,
-        };
-      }),
-      checkout: this.checkoutValue,
-    };
-  }
+
   mustacheViewValueChanged() {
     this.renderCart();
   }
@@ -798,7 +785,6 @@ async increment(event: Event) {
   cartTargetConnected() {
     this.renderCart();
   }
-
 
   renderCart() {
     for (const template of this.templateTargets || []) {
@@ -904,13 +890,6 @@ function shopifyId(id: any) {
     return id.replace(new RegExp("gid://shopify/[a-zA-Z]+/"), "");
   }
   return id;
-}
-
-function stringToVariantURI(variantId: any) {
-  if (variantId.toString().startsWith("gid://shopify/ProductVariant/")) {
-    return variantId;
-  }
-  return `gid://shopify/ProductVariant/${variantId}`;
 }
 
 function stringify(x: any) {

--- a/frontend/controllers/product-controller.ts
+++ b/frontend/controllers/product-controller.ts
@@ -200,6 +200,14 @@ export default class ShopifyBuyControllerBase extends Controller {
   }
 
   async addDeliveryAddress(cartId: string) {
+    const shippingAddress = this.shippingAddress;
+
+    if (!shippingAddress) {
+      console.error(
+        "No shipping address found, skipping delivery address update."
+      );
+      return;
+    }
     const mutation = `
       mutation cartDeliveryAddressesAdd($addresses: [CartSelectableAddressInput!]!, $cartId: ID!) {
         cartDeliveryAddressesAdd(addresses: $addresses, cartId: $cartId) {
@@ -222,16 +230,16 @@ export default class ShopifyBuyControllerBase extends Controller {
         {
           address: {
             deliveryAddress: {
-              address1: "26a Brookwood Road",
-              address2: "",
-              city: "London",
-              company: "",
-              countryCode: "GB",
-              firstName: "Anna",
-              lastName: "Cunnane",
-              phone: "07712345678",
-              provinceCode: "",
-              zip: "",
+              address1: shippingAddress.address1,
+              address2: shippingAddress.address2,
+              city: shippingAddress.city,
+              company: shippingAddress.company,
+              countryCode: shippingAddress.country,
+              firstName: shippingAddress.firstName,
+              lastName: shippingAddress.lastName,
+              phone: "",
+              provinceCode: shippingAddress.province,
+              zip: shippingAddress.zip,
             },
           },
           oneTimeUse: true,
@@ -249,8 +257,6 @@ export default class ShopifyBuyControllerBase extends Controller {
         "Error adding delivery address:",
         data.data.cartDeliveryAddressesAdd.userErrors
       );
-    } else {
-      console.log("Delivery address successfully added.");
     }
   }
 
@@ -640,12 +646,23 @@ export default class ShopifyBuyControllerBase extends Controller {
       this.mustacheViewValue = { ...this.mustacheViewValue, loading: false };
     }
   }
-
   get shippingAddress() {
     try {
+      const [firstName, lastName] = this.stripeShippingValue?.name.split(
+        " "
+      ) || ["", ""];
       return this.stripeShippingValue
         ? {
+            address1: this.stripeShippingValue.address.line1,
+            address2: this.stripeShippingValue.address.line1,
+            city: this.stripeShippingValue.address.city,
+            province: this.stripeShippingValue.address.state,
+            zip: this.stripeShippingValue.address.postal_code,
             country: this.stripeShippingValue.address.country,
+            company: "",
+            firstName,
+            lastName,
+            phone: "",
           }
         : undefined;
     } catch (e) {

--- a/frontend/controllers/product-controller.ts
+++ b/frontend/controllers/product-controller.ts
@@ -647,8 +647,8 @@ async add({ params: { variantId } }: any) {
             title: lineItem.merchandise.product.title,
             variantId: lineItem.merchandise.id,
             canDecreaseQuantity: lineItem.quantity > 1,
-            imageUrl: productImages?.[0]?.node?.url || '/placeholder.png',
-            imageAlt: productImages?.[0]?.node?.altText || 'Product Image',
+            imageUrl: productImages?.[0]?.node?.url,
+            imageAlt: productImages?.[0]?.node?.altText
           };
         }),
         checkout: cart.checkoutUrl,

--- a/frontend/controllers/product-controller.ts
+++ b/frontend/controllers/product-controller.ts
@@ -266,7 +266,7 @@ export default class ShopifyBuyControllerBase extends Controller {
       ...(Object.keys(buyerIdentity).length > 0 && { buyerIdentity }),
     };
 
-    const cartCreateQuery = `
+    const mutation = `
         mutation cartCreate($input: CartInput!) {
           cartCreate(input: $input) {
             cart {
@@ -290,7 +290,7 @@ export default class ShopifyBuyControllerBase extends Controller {
           }
         }
       `;
-    const data = await this.shopifyRequest(cartCreateQuery, { input });
+    const data = await this.shopifyRequest(mutation, { input });
     const newCart = data?.data?.cartCreate?.cart;
 
     if (!newCart) {
@@ -309,7 +309,7 @@ export default class ShopifyBuyControllerBase extends Controller {
   async add({ params: { variantId } }: { params: { variantId: string } }) {
     if (!this.cartId) return;
 
-    const query = `
+    const mutation = `
       mutation {
         cartLinesAdd(cartId: "${this.cartId}", lines: [
           {
@@ -367,7 +367,7 @@ export default class ShopifyBuyControllerBase extends Controller {
         }
       }`;
 
-    const data = await this.shopifyRequest(query);
+    const data = await this.shopifyRequest(mutation);
     if (data?.data?.cartLinesAdd?.cart)
       this.updateCartState(data.data.cartLinesAdd.cart);
   }
@@ -388,7 +388,7 @@ export default class ShopifyBuyControllerBase extends Controller {
       return;
     }
 
-    const query = `
+    const mutation = `
     mutation {
       cartLinesRemove(cartId: "${this.cartId}", lineIds: ["${lineItemId}"]) {
         cart {
@@ -441,12 +441,12 @@ export default class ShopifyBuyControllerBase extends Controller {
       }
     }`;
 
-    await this.shopifyRequest(query);
+    await this.shopifyRequest(mutation);
     await this.getCart();
   }
 
   async updateCartQuantity(lineItemId: string, newQuantity: number) {
-    const query = `
+    const mutation = `
       mutation {
         cartLinesUpdate(cartId: "${this.cartId}", lines: [
           {
@@ -483,7 +483,7 @@ export default class ShopifyBuyControllerBase extends Controller {
         }
       }`;
 
-    const data = await this.shopifyRequest(query);
+    const data = await this.shopifyRequest(mutation);
     if (data?.data?.cartLinesUpdate?.cart)
       this.updateCartState(data.data.cartLinesUpdate.cart);
   }

--- a/frontend/controllers/product-controller.ts
+++ b/frontend/controllers/product-controller.ts
@@ -402,8 +402,6 @@ async add({ params: { variantId } }: any) {
     const data = await response.json();
     const cart = data?.data?.cartLinesAdd?.cart;
 
-    console.log('Add product response:', cart);
-
     if (cart) {
       this.cartValue = cart;
       this.mustacheViewValue = {
@@ -427,7 +425,6 @@ async add({ params: { variantId } }: any) {
         totalCost: cart.cost.totalAmount.amount,
         currency: cart.cost.totalAmount.currencyCode
       };
-      console.log('Mustache view:', this.mustacheViewValue);
     } else {
       console.error('Failed to add item to cart:', data?.data?.cartLinesAdd?.userErrors);
       this.mustacheViewValue = { ...this.mustacheViewValue, loading: false };

--- a/frontend/controllers/product-controller.ts
+++ b/frontend/controllers/product-controller.ts
@@ -4,7 +4,6 @@ import { createStorefrontApiClient } from '@shopify/storefront-api-client';
 import Mustache from "mustache";
 import Wax from "@jvitela/mustache-wax";
 Wax(Mustache, { currency, pluralize, length, shopifyId, stringify });
-import { isAfter } from "date-fns";
 
 interface CartValue {
   id: string;
@@ -240,21 +239,11 @@ async resetCart(): Promise<CartValue | null> {
 
     const apiUrl = `https://${this.shopifyDomainValue}/api/2024-10/graphql.json`;
 
-    // Check if user email and shipping address exist
-    const hasEmail = Boolean(this.userEmailValue);
-    const hasShippingAddress = Boolean(this.shippingAddress);
-
     // Construct the buyerIdentity object 
     const buyerIdentity: { email?: string; shippingAddress?: MailingAddressInput } = {};
-
-    if (hasEmail) {
-      buyerIdentity.email = this.userEmailValue!;
-    }
-
-    if (hasShippingAddress) {
-      buyerIdentity.shippingAddress = this.shippingAddress!;
-    }
-
+    buyerIdentity.email = this.userEmailValue;
+    buyerIdentity.shippingAddress = this.shippingAddress;
+    
     const input: Record<string, any> = { lines: [] };
     if (Object.keys(buyerIdentity).length > 0) {
       input.buyerIdentity = buyerIdentity;

--- a/frontend/controllers/product-controller.ts
+++ b/frontend/controllers/product-controller.ts
@@ -1,6 +1,6 @@
 import { Controller } from "@hotwired/stimulus";
 import type { StripeShippingAddressElementChangeEvent } from "@stripe/stripe-js";
-import Client, { Address, MoneyV2 } from "shopify-buy";
+import { createStorefrontApiClient } from '@shopify/storefront-api-client';
 import Mustache from "mustache";
 import Wax from "@jvitela/mustache-wax";
 Wax(Mustache, { currency, pluralize, length, shopifyId, stringify });
@@ -37,11 +37,18 @@ export default class ShopifyBuyControllerBase extends Controller {
   public mustacheViewValue!: any;
 
   // Internal
-  public client: Client.Client | undefined;
+  public client: ReturnType<typeof createStorefrontApiClient> | undefined;
 
   async connect() {
-    this.getCart();
+    this.client = createStorefrontApiClient({
+      storeDomain: "https://left-book-club-shop.myshopify.com/",
+      apiVersion: "2024-10",
+      publicAccessToken: this.shopifyStorefrontAccessTokenValue!,
+    });
+    console.log('Shopify client initialized', this.client);
   }
+
+
 
   updateAddToCartButton() {
     const selectedOption = this.variantSelectorTarget.options[this.variantSelectorTarget.selectedIndex];

--- a/frontend/controllers/product-controller.ts
+++ b/frontend/controllers/product-controller.ts
@@ -130,12 +130,6 @@ export default class ShopifyBuyControllerBase extends Controller {
         publicAccessToken: this.shopifyStorefrontAccessTokenValue!,
     });
 
-
-   
-    if (!this.cartId) {
-        return this.resetCart();
-    }
-
     const query = `
     query {
       cart(id: "${this.cartId}") {
@@ -231,14 +225,8 @@ export default class ShopifyBuyControllerBase extends Controller {
         body: JSON.stringify({ data: { query } }),
       });
       const data = await response.json();
-      const cart = data?.data?.cart;
-
-        if (!cart) {
-            console.warn('Cart not found. Resetting cart.');
-            return this.resetCart();
-        }
-
-        return cart;
+      const cart = data?.data?.cart; 
+      return cart;
 
     } catch (error) {
         console.error('Failed to fetch cart:', error);
@@ -331,7 +319,7 @@ async resetCart(): Promise<CartValue | null> {
   }
 }
 
-async add({ params: { variantId } }: any) {
+async add({ params: { variantId } }: { params: { variantId: string } }) {
   if (!this.cartId) return;
 
   this.mustacheViewValue = { ...this.mustacheViewValue, loading: true };
@@ -452,7 +440,6 @@ async add({ params: { variantId } }: any) {
       return;
     }
 
-  
     this.mustacheViewValue = { ...this.mustacheViewValue, loading: true };  
   
     const apiUrl = `https://${this.shopifyDomainValue}/api/2024-10/graphql.json`;

--- a/frontend/controllers/product-controller.ts
+++ b/frontend/controllers/product-controller.ts
@@ -892,12 +892,18 @@ function pluralize(count: number, word: string, plural?: string) {
   return count === 1 ? word : plural || word + "s";
 }
 
+interface Money {
+  amount: string;
+  currencyCode: string;
+}
+
 function currency(
-  money: string | number | MoneyV2 | undefined,
+  money: string | number | Money | undefined,
   currencyCode = "GBP"
-) {
+): string {
   if (!money) return "";
-  else if (typeof money === "string") {
+  
+  if (typeof money === "string") {
     money = parseFloat(money).toFixed(2);
   } else if (typeof money === "number") {
     money = money.toFixed(2);
@@ -905,6 +911,7 @@ function currency(
     currencyCode = money.currencyCode;
     money = parseFloat(money.amount).toFixed(2);
   }
+  
   return (currencyCode === "GBP" ? "£" : currencyCode + " ") + money;
 }
 

--- a/frontend/controllers/product-controller.ts
+++ b/frontend/controllers/product-controller.ts
@@ -199,6 +199,61 @@ export default class ShopifyBuyControllerBase extends Controller {
     window.localStorage.setItem(this.LOCALSTORAGE_CART_ID, id.toString());
   }
 
+  async addDeliveryAddress(cartId: string) {
+    const mutation = `
+      mutation cartDeliveryAddressesAdd($addresses: [CartSelectableAddressInput!]!, $cartId: ID!) {
+        cartDeliveryAddressesAdd(addresses: $addresses, cartId: $cartId) {
+          cart {
+            id
+          }
+          userErrors {
+            field
+            message
+          }
+          warnings {
+            message
+          }
+        }
+      }
+    `;
+
+    const variables = {
+      addresses: [
+        {
+          address: {
+            deliveryAddress: {
+              address1: "26a Brookwood Road",
+              address2: "",
+              city: "London",
+              company: "",
+              countryCode: "GB",
+              firstName: "Anna",
+              lastName: "Cunnane",
+              phone: "07712345678",
+              provinceCode: "",
+              zip: "",
+            },
+          },
+          oneTimeUse: true,
+          selected: true,
+          validationStrategy: "COUNTRY_CODE_ONLY",
+        },
+      ],
+      cartId,
+    };
+
+    const data = await this.shopifyRequest(mutation, variables);
+
+    if (data?.data?.cartDeliveryAddressesAdd?.userErrors.length) {
+      console.error(
+        "Error adding delivery address:",
+        data.data.cartDeliveryAddressesAdd.userErrors
+      );
+    } else {
+      console.log("Delivery address successfully added.");
+    }
+  }
+
   async getCart() {
     const query = `
     query {
@@ -303,6 +358,8 @@ export default class ShopifyBuyControllerBase extends Controller {
 
     this.cartId = newCart.id;
     this.cartValue = newCart;
+    await this.addDeliveryAddress(newCart.id);
+
     return newCart;
   }
 

--- a/frontend/controllers/product-controller.ts
+++ b/frontend/controllers/product-controller.ts
@@ -208,11 +208,13 @@ export default class ShopifyBuyControllerBase extends Controller {
                     imageAlt: productImages?.[0]?.node?.altText
                 };
             });
+            const totalQuantity = lineItems.reduce((sum, item) => sum + item.quantity, 0);
 
             this.mustacheViewValue = {
                 loading: false,
                 hasLineItems: lineItems.length > 0,
                 lineItems,
+                totalQuantity,
                 checkout: cart.checkoutUrl,
                 totalCost: cart.cost.totalAmount.amount,
                 currency: cart.cost.totalAmount.currencyCode,
@@ -423,30 +425,36 @@ async add({ params: { variantId } }: { params: { variantId: string } }) {
 
     const data = await response.json();
     const cart = data?.data?.cartLinesAdd?.cart;
-
     if (cart) {
       this.cartValue = cart;
-      this.mustacheViewValue = {
+    
+          const lineItems = cart.lines.edges.map((edge: any) => {
+        const lineItem = edge.node;
+        const productImages = lineItem.merchandise.product.images.edges;
+    
+        return {
+          id: lineItem.id,
+          quantity: lineItem.quantity,
+          title: lineItem.merchandise.product.title,
+          variantId: lineItem.merchandise.id,
+          canDecreaseQuantity: lineItem.quantity > 1,
+          imageUrl: productImages?.[0]?.node?.url || "",
+          imageAlt: productImages?.[0]?.node?.altText || ""
+        };
+      });
+    
+      const totalQuantity = lineItems.reduce((sum, item) => sum + item.quantity, 0);
+    
+          this.mustacheViewValue = {
         loading: false,
-        hasLineItems: cart.lines.edges.length > 0,
-        lineItems: cart.lines.edges.map((edge: any) => {
-          const lineItem = edge.node;
-          const productImages = lineItem.merchandise.product.images.edges;
-
-          return {
-            id: lineItem.id,
-            quantity: lineItem.quantity,
-            title: lineItem.merchandise.product.title,
-            variantId: lineItem.merchandise.id,
-            canDecreaseQuantity: lineItem.quantity > 1,
-            imageUrl: productImages?.[0]?.node?.url,
-            imageAlt: productImages?.[0]?.node?.altText
-          };
-        }),
+        hasLineItems: lineItems.length > 0,
+        lineItems,
+        totalQuantity, 
         checkout: cart.checkoutUrl,
         totalCost: cart.cost.totalAmount.amount,
         currency: cart.cost.totalAmount.currencyCode
       };
+    
     } else {
       console.error('Failed to add item to cart:', data?.data?.cartLinesAdd?.userErrors);
       this.mustacheViewValue = { ...this.mustacheViewValue, loading: false };
@@ -539,30 +547,36 @@ async add({ params: { variantId } }: { params: { variantId: string } }) {
   
 
   
-      if (cart) {
-        this.cartValue = cart;
-        this.mustacheViewValue = {
-          loading: false,
-          hasLineItems: cart.lines.edges.length > 0,
-          lineItems: cart.lines.edges.map((edge: any) => {
-            const lineItem = edge.node;
-            const productImages = lineItem.merchandise.product.images.edges;
-  
-            return {
-              id: lineItem.id,
-              quantity: lineItem.quantity,
-              title: lineItem.merchandise.product.title,
-              variantId: lineItem.merchandise.id,
-              canDecreaseQuantity: lineItem.quantity > 1,
-              imageUrl: productImages?.[0]?.node?.URL,
-              imageAlt: productImages?.[0]?.node?.altText,
-            };
-          }),
-          checkout: cart.checkoutUrl,
-          totalCost: cart.cost.totalAmount.amount,
-          currency: cart.cost.totalAmount.currencyCode
-        };
-      } else {
+    if (cart) {
+  this.cartValue = cart;
+
+  const lineItems = cart.lines.edges.map((edge: any) => {
+    const lineItem = edge.node;
+    const productImages = lineItem.merchandise.product.images.edges;
+
+    return {
+      id: lineItem.id,
+      quantity: lineItem.quantity,
+      title: lineItem.merchandise.product.title,
+      variantId: lineItem.merchandise.id,
+      canDecreaseQuantity: lineItem.quantity > 1,
+      imageUrl: productImages?.[0]?.node?.url || "", 
+      imageAlt: productImages?.[0]?.node?.altText || "" 
+    };
+  });
+
+ 
+  const totalQuantity = lineItems.reduce((sum, item) => sum + item.quantity, 0);
+  this.mustacheViewValue = {
+      loading: false,
+      hasLineItems: lineItems.length > 0,
+      lineItems,
+      totalQuantity, 
+      checkout: cart.checkoutUrl,
+      totalCost: cart.cost.totalAmount.amount,
+      currency: cart.cost.totalAmount.currencyCode
+    };
+    } else {
         console.error('Failed to remove item from cart:', data?.data?.cartLinesRemove?.userErrors);
         this.mustacheViewValue = { ...this.mustacheViewValue, loading: false };
       }
@@ -656,27 +670,35 @@ async add({ params: { variantId } }: { params: { variantId: string } }) {
 
     if (cart) {
       this.cartValue = cart;
-      this.mustacheViewValue = {
+    
+        const lineItems = cart.lines.edges.map((edge: any) => {
+        const lineItem = edge.node;
+        const productImages = lineItem.merchandise.product.images.edges;
+    
+        return {
+          id: lineItem.id,
+          quantity: lineItem.quantity,
+          title: lineItem.merchandise.product.title,
+          variantId: lineItem.merchandise.id,
+          canDecreaseQuantity: lineItem.quantity > 1,
+          imageUrl: productImages?.[0]?.node?.url || "", 
+          imageAlt: productImages?.[0]?.node?.altText || "" 
+        };
+      });
+    
+     
+      const totalQuantity = lineItems.reduce((sum, item) => sum + item.quantity, 0);
+    
+          this.mustacheViewValue = {
         loading: false,
-        hasLineItems: cart.lines.edges.length > 0,
-        lineItems: cart.lines.edges.map((edge: any) => {
-          const lineItem = edge.node;
-          const productImages = lineItem.merchandise.product.images.edges;
-
-          return {
-            id: lineItem.id,
-            quantity: lineItem.quantity,
-            title: lineItem.merchandise.product.title,
-            variantId: lineItem.merchandise.id,
-            canDecreaseQuantity: lineItem.quantity > 1,
-            imageUrl: productImages?.[0]?.node?.url,
-            imageAlt: productImages?.[0]?.node?.altText
-          };
-        }),
+        hasLineItems: lineItems.length > 0,
+        lineItems,
+        totalQuantity, 
         checkout: cart.checkoutUrl,
         totalCost: cart.cost.totalAmount.amount,
-        currency: cart.cost.totalAmount.currencyCode,
+        currency: cart.cost.totalAmount.currencyCode
       };
+
     } else {
       console.error('Failed to decrement item in cart:', data?.data?.cartLinesUpdate?.userErrors);
       this.mustacheViewValue = { ...this.mustacheViewValue, loading: false };
@@ -766,30 +788,37 @@ async increment(event: Event) {
 
     const data = await response.json();
     const cart = data?.data?.cartLinesUpdate?.cart;
+if (cart) {
+  this.cartValue = cart;
 
-    if (cart) {
-      this.cartValue = cart;
-      this.mustacheViewValue = {
-        loading: false,
-        hasLineItems: cart.lines.edges.length > 0,
-        lineItems: cart.lines.edges.map((edge: any) => {
-          const lineItem = edge.node;
-          const productImages = lineItem.merchandise.product.images.edges;
+  const lineItems = cart.lines.edges.map((edge: any) => {
+    const lineItem = edge.node;
+    const productImages = lineItem.merchandise.product.images.edges;
 
-          return {
-            id: lineItem.id,
-            quantity: lineItem.quantity,
-            title: lineItem.merchandise.product.title,
-            variantId: lineItem.merchandise.id,
-            canDecreaseQuantity: lineItem.quantity > 1,
-            imageUrl: productImages?.[0]?.node?.url,
-            imageAlt: productImages?.[0]?.node?.altText
-          }
-        }),
-        checkout: cart.checkoutUrl,
-        totalCost: cart.cost.totalAmount.amount,
-        currency: cart.cost.totalAmount.currencyCode,
-      };
+    return {
+      id: lineItem.id,
+      quantity: lineItem.quantity,
+      title: lineItem.merchandise.product.title,
+      variantId: lineItem.merchandise.id,
+      canDecreaseQuantity: lineItem.quantity > 1,
+      imageUrl: productImages?.[0]?.node?.url || "", 
+      imageAlt: productImages?.[0]?.node?.altText || "" 
+    };
+  });
+
+ 
+  const totalQuantity = lineItems.reduce((sum, item) => sum + item.quantity, 0);
+
+  this.mustacheViewValue = {
+    loading: false,
+    hasLineItems: lineItems.length > 0,
+    lineItems,
+    totalQuantity, 
+    checkout: cart.checkoutUrl,
+    totalCost: cart.cost.totalAmount.amount,
+    currency: cart.cost.totalAmount.currencyCode
+  };
+
     } else {
       console.error('Failed to increment item in cart:', data?.data?.cartLinesUpdate?.userErrors);
       this.mustacheViewValue = { ...this.mustacheViewValue, loading: false };
@@ -814,7 +843,6 @@ async increment(event: Event) {
         document.querySelectorAll(template.dataset?.target || "")
       );
       if (els.length) {
-
         for (const el of els) {
           el.innerHTML = Mustache.render(
             template.innerHTML,

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@popperjs/core": "^2.10.2",
     "@sentry/browser": "^6.19.7",
     "@sentry/tracing": "^6.19.7",
+    "@shopify/storefront-api-client": "^1.0.4",
     "@stripe/stripe-js": "^1.27.0",
     "@turf/bbox": "^6.5.0",
     "@types/bootstrap": "^5.2.5",
@@ -48,5 +49,4 @@
     "vite": "^5.0.2"
   },
   "packageManager": "yarn@1.22.22"
-
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -876,6 +876,18 @@
     "@sentry/types" "6.19.7"
     tslib "^1.9.3"
 
+"@shopify/graphql-client@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@shopify/graphql-client/-/graphql-client-1.2.2.tgz#2877f7069a28d2db305e34cdcd896ff1e8c3b735"
+  integrity sha512-bFDxTGgyHNQn7KI+NQjo6mVbCSu6/TIReGCjQx+i8wOKtd9LUlTwLj60kE6ksJUSSAr8CNd5db6CY6aMObtmow==
+
+"@shopify/storefront-api-client@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@shopify/storefront-api-client/-/storefront-api-client-1.0.4.tgz#e74a347a1ec677148dc9c6ada5ae4288d203dab1"
+  integrity sha512-G/brdAHI+EumUosf6s0cKlsc7PJ/+echDzbviqTjmH6stfqA6BtLF1AwnULuDR1AZjS4vnZLEaEbeVrqlAb2Zg==
+  dependencies:
+    "@shopify/graphql-client" "^1.2.2"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"


### PR DESCRIPTION
## Description
This PR installs the @shopify/storefront-api-client and updates the cart functions to use the new GraphQL API
Notes:
@janbaykara I wasn't sure what relation the code in this [file](https://github.com/commonknowledge/leftbookclub/blob/main/frontend/controllers/shopify-buy-controller-base.ts) has to this functionality. It looked like it was maybe duplicated?
We can no longer add a delivery address to the `CartBuyerIdentity` object to pass it to the checkout
https://shopify.dev/docs/api/storefront/2024-10/objects/CartBuyerIdentity
I've kept country code and email pre-filled and I'm sure there's another way to pass the full address in but I've reached the end of the budget. Suggestions welcome!

## Motivation and Context
Addresses issue [LBC-411](https://linear.app/commonknowledge/issue/LBC-411/refactor-the-shopifyapi-package-to-use-graphql)

## How Can It Be Tested?
1. Run locally
2. Add merch items to the cart and remove them
3. Increment and decrement the items in the cart
4. Go to checkout and observe the redirect
5. Also sign up as a member and observe the user information (email) passed to the Shopify checkout 

## How Will This Be Deployed?
Normal CD process

