### PR TITLE
Replace deprecated Stripe coupon= with discounts=[{coupon}]

### DIFF
--- a/app/management/commands/migrate_old_stripe_gift_cards.py
+++ b/app/management/commands/migrate_old_stripe_gift_cards.py
@@ -92,7 +92,7 @@ class Command(BaseCommand):
                         f"🔵 No coupon upgrade required {sub.primary_product.name} [{sub.id}] -- {old_coupon_name} [{old_coupon_id}]"
                     )
                 else:
-                    new_sub = stripe.Subscription.modify(sub.id, coupon=coupon.id)
+                    new_sub = stripe.Subscription.modify(sub.id, discounts=[{'coupon': coupon.id}])
                     sub = LBCSubscription.sync_from_stripe_data(new_sub)
                     print(
                         f"🟢 Updated subscription to use new coupon: {sub.primary_product.name} [{sub.id}] -- {old_coupon_name} [{old_coupon_id}] -> {coupon.name} [{coupon.id}]"

--- a/app/management/commands/reactivate_gift_recipients.py
+++ b/app/management/commands/reactivate_gift_recipients.py
@@ -103,7 +103,7 @@ class Command(BaseCommand):
         new_sub = stripe.Subscription.create(
             customer=customer_id,
             items=items,
-            coupon=coupon.id,
+            discounts=[{'coupon': coupon.id}],
             payment_behavior="allow_incomplete",
             off_session=True,
             metadata={

--- a/app/models/django.py
+++ b/app/models/django.py
@@ -300,7 +300,7 @@ class User(AbstractUser):
         for sub in self.stripe_customer.subscriptions.all():
             if sub.metadata.get("gift_mode", None) is None and not sub.id in keep:
                 try:
-                    stripe.Subscription.delete(sub.id, proration_behavior='create_prorations')
+                    stripe.Subscription.delete(sub.id, prorate=True)
                 except:
                     pass
         self.refresh_stripe_data()

--- a/app/models/django.py
+++ b/app/models/django.py
@@ -300,7 +300,7 @@ class User(AbstractUser):
         for sub in self.stripe_customer.subscriptions.all():
             if sub.metadata.get("gift_mode", None) is None and not sub.id in keep:
                 try:
-                    stripe.Subscription.delete(sub.id, prorate=True)
+                    stripe.Subscription.delete(sub.id, proration_behavior='create_prorations')
                 except:
                     pass
         self.refresh_stripe_data()


### PR DESCRIPTION
## What

Stripe removed singular `coupon=` on Subscription (2025-03-31). Two one-line wraps:

`coupon=...` → `discounts=[{'coupon': ...}]`

A previous commit also rewrote `Subscription.delete(..., prorate=True)`. That was wrong — cancel still uses `prorate` — and has been reverted.

No auto-merge. Tests not run here.

Changelog: https://docs.stripe.com/changelog/basil/2025-03-31/deprecate-singular-coupon-promotion-code